### PR TITLE
Display the web application

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,9 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
-  url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
 }
 
 model User {
@@ -89,10 +88,10 @@ model LogEntry {
 }
 
 model Verification {
-  id         String             @id @default(cuid())
-  logEntryId String             @unique
+  id         String    @id @default(cuid())
+  logEntryId String    @unique
   verifierId String?
-  status     VerificationStatus @default(PENDING)
+  status     String    @default("PENDING") // PENDING, APPROVED, REJECTED
   reason     String?
   timestamp  DateTime?
 
@@ -100,12 +99,6 @@ model Verification {
   verifier User?    @relation("VerifierVerifications", fields: [verifierId], references: [id])
 
   @@index([status])
-}
-
-enum VerificationStatus {
-  PENDING
-  APPROVED
-  REJECTED
 }
 
 model Topic {


### PR DESCRIPTION
Configure Prisma to use SQLite and convert `VerificationStatus` enum to a string field to enable local development.

The original Prisma schema was configured for PostgreSQL, but SQLite was chosen for local development. Since SQLite does not support enum types, the `VerificationStatus` enum was converted to a string field to ensure compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-763cdb4c-88e6-4566-9183-da9407d34e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-763cdb4c-88e6-4566-9183-da9407d34e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

